### PR TITLE
Add extra tests with \r\r\n for additional Postfix vulnerability

### DIFF
--- a/smtp_smuggling_scanner.py
+++ b/smtp_smuggling_scanner.py
@@ -18,6 +18,9 @@ eod_sequences = [
     "\r\n.\n",
     "\r.\r\n",
     "\r\n.\r",
+    "\r\n.\r\r\n",
+    "\r\r\n.\r\n",
+    "\r\r\n.\r\r\n",
     "\r\n\x00.\r\n",
     "\r\n.\x00\r\n"
 ]


### PR DESCRIPTION
as Postfix condenses multiple CR followed by LF into a single CRLF:
https://marc.info/?l=postfix-users&m=170456217431710&w=2

So this works even with patched Postfix and `smtpd_forbid_bare_newline=yes`.