### PR TITLE
Fix for specifying 'inbound_smtp_server'

### DIFF
--- a/smtp_smuggling_scanner.py
+++ b/smtp_smuggling_scanner.py
@@ -401,6 +401,8 @@ if __name__ == '__main__':
         except Exception as e:
             out.alert(f"Didn't find an MX record for domain {receiver_domain}! Is this a valid receiver domain?")
             quit()
+    elif args.inbound_smtp_server:
+        inbound_smtp_server = args.inbound_smtp_server
 
     if args.setup_check and not args.outbound_smtp_server:
         out.info("Running inbound setup check!")


### PR DESCRIPTION
This fixes:
NameError: name 'inbound_smtp_server' is not defined

When trying to define a inbound_smtp_server without doing MX lookup